### PR TITLE
No system xdg

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -16,15 +16,15 @@ It assumes the following folders are standard paths of each environment:
      * MacOSX:
    - * System level configuration folder
      * ``%PROGRAMDATA%`` (``C:\\ProgramData``)
-     * ``${XDG_CONFIG_DIRS}`` (``/etc/xdg``)
+     * ``${XDG_CONFIG_DIRS}``, otherwise (``/etc``)
      * ``/Library/Application Support``
    - * User level configuration folder
      * ``%APPDATA%`` (``C:\\Users\\<User>\\AppData\\Roaming``)
-     * ``${XDG_CONFIG_HOME}`` (``${HOME}/.config``)
+     * ``${XDG_CONFIG_HOME}``, otherwise (``${HOME}/.config``)
      * ``${HOME}/Library/Application Support``
    - * User wide cache folder
      * ``%LOCALAPPDATA%`` ``(C:\\Users\\<User>\\AppData\\Local)``
-     * ``${XDG_CACHE_HOME}`` (``${HOME}/.cache``)
+     * ``${XDG_CACHE_HOME}``, otherwise (``${HOME}/.cache``)
      * ``${HOME}/Library/Caches``
 
 Examples
@@ -37,7 +37,7 @@ Getting Configuration
 
 * Local path (if you add the path via LocalPath parameter)
 * User level configuration folder(e.g. ``$HOME/.config/<vendor-name>/<application-name>/setting.json`` in Linux)
-* System level configuration folder(e.g. ``/etc/xdg/<vendor-name>/<application-name>/setting.json`` in Linux)
+* System level configuration folder(e.g. ``/etc/<vendor-name>/<application-name>/setting.json`` in Linux)
 
 ``configdir.Config`` provides some convenient methods(``ReadFile``, ``WriteFile`` and so on).
 

--- a/config.go
+++ b/config.go
@@ -2,20 +2,20 @@
 //
 // System wide configuration folders:
 //
-//   - Windows: %PROGRAMDATA% (C:\ProgramData)
-//   - Linux/BSDs: ${XDG_CONFIG_DIRS} (/etc/xdg)
+//   - Windows: %PROGRAMDATA%, otherwise C:\ProgramData
+//   - Linux/BSDs: ${XDG_CONFIG_DIRS}, otherwise /etc
 //   - MacOSX: "/Library/Application Support"
 //
 // User wide configuration folders:
 //
 //   - Windows: %APPDATA% (C:\Users\<User>\AppData\Roaming)
-//   - Linux/BSDs: ${XDG_CONFIG_HOME} (${HOME}/.config)
+//   - Linux/BSDs: ${XDG_CONFIG_HOME}, otherwise ${HOME}/.config
 //   - MacOSX: "${HOME}/Library/Application Support"
 //
 // User wide cache folders:
 //
-//   - Windows: %LOCALAPPDATA% (C:\Users\<User>\AppData\Local)
-//   - Linux/BSDs: ${XDG_CACHE_HOME} (${HOME}/.cache)
+//   - Windows: %LOCALAPPDATA%, otherwise C:\Users\<User>\AppData\Local
+//   - Linux/BSDs: ${XDG_CACHE_HOME, otherwise ${HOME}/.cache
 //   - MacOSX: "${HOME}/Library/Caches"
 //
 // configdir returns paths inside the above folders.

--- a/config_linux.go
+++ b/config_linux.go
@@ -1,4 +1,4 @@
-// +build !windows,!darwin
+// +build linux
 
 package configdir
 
@@ -24,7 +24,7 @@ func init() {
 	if os.Getenv("XDG_CONFIG_DIRS") != "" {
 		systemSettingFolders = strings.Split(os.Getenv("XDG_CONFIG_DIRS"), ":")
 	} else {
-		systemSettingFolders = []string{"/etc/xdg"}
+		systemSettingFolders = []string{"/etc"}
 	}
 	if os.Getenv("XDG_CACHE_HOME") != "" {
 		cacheFolder = os.Getenv("XDG_CACHE_HOME")


### PR DESCRIPTION
This is mostly a preference: This puts Linux system-wide configuration files directly in `/etc`, while user files may still end up in `~/.config`/`~/.cache`.